### PR TITLE
Week2 [STEP3] moook

### DIFF
--- a/CodeStarterCamp_Week2/main.swift
+++ b/CodeStarterCamp_Week2/main.swift
@@ -11,7 +11,7 @@ import Foundation
 var lottoNumbers: Set<Int> = []
 let myLottoNumbers: [Int] = [1, 2, 3, 4, 5, 6]
 var matchingNumbers: [Int] = []
-var lottoNumbersPerRound: [String: Any] = [:]
+var lottoNumbersPerRound: [String: [Int]] = [:]
 var round: Int = 0
 
 func generateLottoNumbers() {
@@ -30,7 +30,7 @@ func findMatchingNumbers() {
     matchingNumbers = lottoNumbers.intersection(myLottoNumbers).sorted()
 }
 
-func printMatchingNumbers() {
+func printMatchingNumbers(where matchingNumbers: inout [Int]) {
     while matchingNumbers.isEmpty == false {
         if matchingNumbers.count == 1 {
             if let matchingNumber = matchingNumbers.first {
@@ -47,15 +47,25 @@ func printMatchingNumbers() {
 }
 
 func printResult() {
+    findMatchingNumbers()
     if matchingNumbers.isEmpty == false {
         print("축하합니다! 겹치는 번호는 ", terminator: "")
-        printMatchingNumbers()
+        printMatchingNumbers(where: &matchingNumbers)
         print(" 입니다!")
     } else {
         print("아쉽지만 겹치는 번호가 없습니다.")
     }
 }
 
-generateLottoNumbers()
-findMatchingNumbers()
-printResult()
+func printSecondLottoNumbers() {
+    if var secondLottoNumbers: [Int] = lottoNumbersPerRound["2회차"] {
+        print("2회차의 로또 당첨 번호는", terminator: " ")
+        printMatchingNumbers(where: &secondLottoNumbers)
+        print(" 입니다.")
+    }
+}
+
+for _ in 1...5 {
+    generateLottoNumbers()
+}
+printSecondLottoNumbers()

--- a/CodeStarterCamp_Week2/main.swift
+++ b/CodeStarterCamp_Week2/main.swift
@@ -11,11 +11,19 @@ import Foundation
 var lottoNumbers: Set<Int> = []
 let myLottoNumbers: [Int] = [1, 2, 3, 4, 5, 6]
 var matchingNumbers: [Int] = []
+var lottoNumbersPerRound: [String: Any] = [:]
+var round: Int = 0
 
 func generateLottoNumbers() {
     while lottoNumbers.count<6 {
         lottoNumbers.insert(Int.random(in: 1...45))
     }
+    recordLottoNumbersPerRound()
+}
+
+func recordLottoNumbersPerRound() {
+    round += 1
+    lottoNumbersPerRound["\(round)"+"회차"] = lottoNumbers.sorted()
 }
 
 func findMatchingNumbers() {


### PR DESCRIPTION
@hcooch2ch3 
스텝3 PR보냅니다! 🌰 
```
2회차의 로또 당첨 번호는 [6, 9, 13, 32, 34, 45] 입니다.
```
```
2회차의 로또 당첨 번호는 6, 9, 13, 32, 34, 45 입니다.
```
위에처럼 당첨번호의 대괄호[]를 없애려고 
step2에서 사용했던 함수인
```swift
printMatchingNumbers()
```
함수를 
```swift
printMatchingNumbers(where matchingNumbers: [Int])
```
로 매개변수를 이용하여 여러 곳에서 사용할 수 있게 시도했는데 

```
⚠️ Cannot use mutating member on immutable value: 'matchingNumbers' is a 'let' constant
```
이런 컴파일 오류가 나왔고 swift에서 함수의 매개변수는 기본적으로 상수타입으로 전달이 된다는 사실을 알았습니다.

그래서 

```swift
printMatchingNumbers(where matchingNumbers: inout [Int])

printMatchingNumbers(where: &secondLottoNumbers)
```

함수의 선언에 inout , 호출할 매개변수 자리앞에 & 를 사용하여
직접 매개변수 값에 접근하여 해결할 수 있었습니다. 😄 