### PR TITLE
Week2 [STEP 3] JW

### DIFF
--- a/CodeStarterCamp_Week2/main.swift
+++ b/CodeStarterCamp_Week2/main.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 let myLottoNumbers: [Int] = [3,8,15,16,31,44]
+var pastWinningNumbers: [String: [Int]] = [:]
 
 func makeWinningNumbers() -> Array<Int> {
     var lottery: [Int] = []
@@ -35,4 +36,29 @@ func checkLottery(_: Array<Int>) {
     }
 }
 
-checkLottery(myLottoNumbers)
+func savePastWinningNumbers(theNumbers: Array<Int>) {
+    let arrayFromKeys = Array(pastWinningNumbers.keys)
+    
+    if arrayFromKeys.isEmpty {
+        pastWinningNumbers["1회차"] = theNumbers
+    } else {
+        let sortedArrayFromKeys = arrayFromKeys.sorted()
+        let lastTurn: String = sortedArrayFromKeys.last ?? "0회차"
+        let thisTurn = (Int(lastTurn.prefix(1)) ?? 0) + 1
+        let thisTurnKey = String(thisTurn) + "회차"
+        pastWinningNumbers[String(thisTurnKey)] = theNumbers
+    }
+}
+
+for _ in 1...5 {
+    let theNumbers = makeWinningNumbers()
+    savePastWinningNumbers(theNumbers: theNumbers)
+}
+
+let pastRound: String = "2회차"
+let win = pastWinningNumbers[pastRound] ?? [0]
+let winningNums = win.map{ String($0) }
+
+print("\(pastRound)의 로또 당첨 번호는 ", terminator: "")
+print(winningNums.joined(separator: ", "), terminator: " ")
+print("입니다.")


### PR DESCRIPTION
@gzzjk159
## 고민했던 점 
### 딕셔너리에 저장되어있는 특정 키를 숫자에 근거해 가져오는 문제 

- 딕셔너리는 어레이처럼 인덱스가 있지 않는 타입이기 때문에, 어떻게 숫자상으로 마지막인 키를 가져와 그것에 +1 을 해 지금 회차인 key를 만들지 고민이 되었습니다. 
(예를 들어, [“1회차”: [1, 2, 3, 4, 5, 6] , “2회차”: [1, 4, 6, 7, 8, 9]]까지 저장된 상태에서 “2회차” 라는 키를 가져와 2에 +1을 해 새롭게 “3회차”: [2, 3, 4, 5, 6, 7] 를 저장하는 상황입니다)

- 고민과 검색 끝에 결국 현재 딕셔너리의 키만을 어레이로 가져오며 .sorted() 메소드를 취하는 것으로 방법을 찾았습니다. 이렇게 하면 순서가 없기 때문에 [“1회차”: [~~], “3회차”:[~~], “2회차”:[~~]] 이런 식으로 섞여 저장되어있는 딕셔너리의 키들도 1,2,3,4,5회차 순서의 어레이로 가져올 수 있습니다. 이 어레이의 마지막 원소에서 첫글자만 +1 을 한 뒤, “회차”를 붙여 새로운 회차 이름을 만들 수 있었습니다. 그리고 만든 새로운 회차 이름을 키로, 새로운 로또당첨 번호를 밸류로 해 딕셔너리에 저장하는 방식으로 savePastWinningNumbers() 메소드를 마무리했습니다.

---
## 해결이 되지 않은 점  
- 없습니다. 

--- 
## 조언을 얻고 싶은 부분 
### [Int] 를 [] 없이 출력하는 방법 
- Step2에서도 똑같은 부분이 있었는데 질문하는걸 잊어서 지금 질문합니다. Int 타입 배열의 원소 전부를 괄호 없이 출력하는 방법(맨 뒤 , 없이)은 [Int] 를 [String]으로 바꾼 뒤 .joined() 메소드를 사용하는 것이 최선인가요? joined의 특성상 String으로 배열의 타입을 바꾸는게 불가피한 것 같은데, 이 과정이 없으면 더 좋겠다는 생각이 듭니다. for문으로 원소를 하나하나 출력할 수도 있겠지만 그렇게하면 terminator: “,” 때문에 마지막 원소 뒤에도 ,가 붙어 원하는 출력 형태가 아니게 되어 사용할 수 없었습니다. 조언 부탁드립니다.